### PR TITLE
adding support for async consumer context (like apollo server does)

### DIFF
--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -179,7 +179,8 @@ export class Server<C extends BaseContext> {
 
     debug('start:ApolloServerAllocation:start');
     this.graphQLServer = new ApolloServer({
-      context: (options: { req: Request }) => {
+      context: async (options: { req: Request }) => {
+        const consumerCtx = await contextGetter(options.req);
         return {
           connection: this.connection,
           dataLoader: {
@@ -188,7 +189,7 @@ export class Server<C extends BaseContext> {
           },
           request: options.req,
           // Allows consumer to add to the context object - ex. context.user
-          ...contextGetter(options.req)
+          ...consumerCtx,
         };
       },
       introspection: this.introspection,


### PR DESCRIPTION
The way that the App constructor works, the consumer context hook function is not asynchronous, but the underlying ApolloServer.context supports returning a Promise<Ctx> as well as a regular Ctx.

It would be really helpful if adopting clients could take advantage of that async functionality ...

I had to skip linting, because unrelated code failed the lint.  The proposed changes should work perfectly fine for async and non-async use cases, with no additional side-affects introduced.