### PR TITLE
fix(createMany) - Fix errors being swallowed on createMany

### DIFF
--- a/src/core/BaseService.ts
+++ b/src/core/BaseService.ts
@@ -118,13 +118,13 @@ export class BaseService<E extends BaseModel> {
     // Validate against the the data model
     // Without `skipMissingProperties`, some of the class-validator validations (like MinLength)
     // will fail if you don't specify the property
-    results.forEach(async obj => {
+    for (const obj of results) {
       const errors = await validate(obj, { skipMissingProperties: true });
       if (errors.length) {
         // TODO: create our own error format that matches Mike B's format
         throw new ArgumentValidationError(errors);
       }
-    });
+    }
 
     // TODO: remove any when this is fixed: https://github.com/Microsoft/TypeScript/issues/21592
     return this.repository.save(results, { reload: true });

--- a/src/test/functional/server.test.ts
+++ b/src/test/functional/server.test.ts
@@ -109,12 +109,30 @@ describe('server', () => {
     expect(results[0].dishes.length).toEqual(20);
   });
 
-  test('throws errors when given bad input', async done => {
+  test('throws errors when given bad input on a single create', async done => {
     expect.assertions(1);
 
     createKitchenSink(binding, '')
       .catch(error => {
-        expect(error).toBeDefined();
+        expect(error).toHaveProperty('message', 'Argument Validation Error\n');
+      })
+      .finally(done);
+  });
+
+  test('throws errors when given bad input on a many create', async done => {
+    expect.assertions(1);
+    const sink = {
+      dateField: '2000-03-26T19:39:08.597Z',
+      stringField: 'Trantow',
+      emailField: '',
+      integerField: 41,
+      booleanField: false,
+      floatField: -1.3885
+    };
+
+    createManyKitchenSinks(binding, [sink])
+      .catch(error => {
+        expect(error).toHaveProperty('message', 'Argument Validation Error\n');
       })
       .finally(done);
   });
@@ -388,8 +406,8 @@ async function updateKitchenSink(
   );
 }
 
-async function createManyKitchenSinks(binding: any): Promise<KitchenSink> {
-  return binding.mutation.createManyKitchenSinks({ data: KITCHEN_SINKS }, `{ id }`);
+async function createManyKitchenSinks(binding: any, data = KITCHEN_SINKS): Promise<KitchenSink> {
+  return binding.mutation.createManyKitchenSinks({ data }, `{ id }`);
 }
 
 async function createManyDishes(binding: any, kitchenSinkId: string): Promise<KitchenSink> {


### PR DESCRIPTION
`forEach` doesn't support passing `async` callbacks to it; as a result, errors from `createMany` object validation wouldn't bubble up. This PR fixes that by waiting on each object in the list to be validated.