### PR TITLE
fix(code-generator): remove magic Id logic

### DIFF
--- a/src/decorators/ManyToOne.ts
+++ b/src/decorators/ManyToOne.ts
@@ -7,6 +7,9 @@ import { StringField } from '../decorators';
 import { composeMethodDecorators, MethodDecoratorFactory } from '../utils';
 
 export function ManyToOne(parentType: any, joinFunc: any, options: any = {}): any {
+  // TODO: GENERATOR: remove when we use metadata to do codegen
+  options = { ...options, comment: 'warthog_foreign_key' };
+
   // Need to grab the class name from within a decorator
   let klass: string;
   const extractClassName = (target: any): any => {

--- a/src/decorators/StringField.ts
+++ b/src/decorators/StringField.ts
@@ -9,12 +9,16 @@ interface StringFieldOptions {
   minLength?: number;
   nullable?: boolean;
   unique?: boolean;
+  comment?: string; // TODO: GENERATOR: remove when we use metadata to do codegen
 }
 
 export function StringField(args: StringFieldOptions = {}): any {
   const nullableOption = args.nullable === true ? { nullable: true } : {};
   const maxLenOption = args.maxLength ? { length: args.maxLength } : {};
   const uniqueOption = args.unique ? { unique: true } : {};
+
+  // TODO: GENERATOR: remove when we use metadata to do codegen
+  const commentOption = args.comment ? { comment: args.comment } : {};
 
   // These are the 2 required decorators to get type-graphql and typeorm working
   const factories = [
@@ -27,7 +31,8 @@ export function StringField(args: StringFieldOptions = {}): any {
       type: 'varchar',
       ...maxLenOption,
       ...nullableOption,
-      ...uniqueOption
+      ...uniqueOption,
+      ...commentOption // TODO: GENERATOR: remove when we use metadata to do codegen
     }) as MethodDecoratorFactory
   ];
 

--- a/src/schema/TypeORMConverter.ts
+++ b/src/schema/TypeORMConverter.ts
@@ -52,7 +52,9 @@ export function columnToGraphQLType(column: ColumnMetadata): GraphQLScalarType |
   // Check to see if this column is an enum and return that
   if (column.enum) {
     return extractEnumObject(column);
-  } else if (column.propertyName.match(/Id$/)) {
+  }
+  // TODO: GENERATOR: remove when we use metadata to do codegen
+  else if (column.comment === 'warthog_foreign_key') {
     return GraphQLID;
   }
 


### PR DESCRIPTION
HACK: this change makes it so that the only magic ID columns are those created by the Warthog `ManyToOne` decorator.  All other columns that end in `Id` are considered the data type that they're decorated by.

Behind the scenes, we use a hack by where we add a comment to the field - `warthog_id_column`.  If this comment exists on the field, then it will be considered an ID column.  This hack should be considered a "private API" and not exploited to create additional ID columns.  I'll be putting in a proper fix within the next week that will decorate the schema directly from the Warthog decorators.

