### PR TITLE
fix(magic-id): remove magic id logic

### DIFF
--- a/src/decorators/StringField.ts
+++ b/src/decorators/StringField.ts
@@ -3,7 +3,7 @@ import { MaxLength, MinLength } from 'class-validator';
 import { Field } from 'type-graphql';
 import { Column, ColumnType } from 'typeorm';
 
-import { FieldType, decoratorDefaults, getMetadataStorage } from '../metadata';
+import { decoratorDefaults, getMetadataStorage } from '../metadata';
 import { composeMethodDecorators, MethodDecoratorFactory } from '../utils';
 
 interface StringFieldOptions {
@@ -23,22 +23,7 @@ export function StringField(args: StringFieldOptions = decoratorDefaults): any {
   const uniqueOption = options.unique ? { unique: true } : {};
 
   const registerWithWarthog = (target: object, propertyKey: string): any => {
-    // Sorry, I put in some magic that automatically identified columns that end in Id to be ID columns
-    // that only uses the ID filter (eq and in).  This was silly.  I've added a workaround here where you
-    // can explicitly state which filter you want to use.  So if you have a field called userId and add filter: 'string'
-    // this will bypass the magic Id logic below
-    let fieldType: FieldType = 'string'; // default
-
-    const explicitType = typeof args.filter === 'string' ? args.filter : null;
-    if (explicitType) {
-      fieldType = explicitType;
-    }
-    // V2: remove the auto-ID logic.  Need to keep this around as to not introduce a breaking change
-    else if (propertyKey.match(/Id$/)) {
-      fieldType = 'id';
-    }
-
-    getMetadataStorage().addField(fieldType, target.constructor.name, propertyKey, options);
+    getMetadataStorage().addField('string', target.constructor.name, propertyKey, options);
   };
 
   // These are the 2 required decorators to get type-graphql and typeorm working


### PR DESCRIPTION
BREAKING CHANGE: we previously set a field as an ID field if it
ended in `Id`.  This magic caused a lot of issues.  We no longer
do this, so you'll need to use the @IdField decorator instead