### PR TITLE
fix(decorators): fix BooleanField default and WhereUnique query variable list

### DIFF
--- a/src/decorators/BooleanField.ts
+++ b/src/decorators/BooleanField.ts
@@ -17,7 +17,8 @@ interface BooleanFieldOptions {
 export function BooleanField(args: BooleanFieldOptions = {}): any {
   const options = { ...decoratorDefaults, ...args };
   const nullableOption = options.nullable === true ? { nullable: true } : {};
-  const defaultOption = options.default ? { default: options.default } : {};
+  const defaultOption =
+    options.default === true || options.default === false ? { default: options.default } : {};
 
   const factories = [
     WarthogField('boolean', options),

--- a/src/decorators/BooleanField.ts
+++ b/src/decorators/BooleanField.ts
@@ -12,6 +12,7 @@ interface BooleanFieldOptions {
   filter?: boolean;
   nullable?: boolean;
   sort?: boolean;
+  editable?: boolean;
 }
 
 export function BooleanField(args: BooleanFieldOptions = {}): any {

--- a/src/decorators/EnumField.ts
+++ b/src/decorators/EnumField.ts
@@ -7,9 +7,10 @@ import { decoratorDefaults, getMetadataStorage } from '../metadata';
 import { composeMethodDecorators, generatedFolderPath, MethodDecoratorFactory } from '../utils';
 
 interface EnumFieldOptions {
-  nullable?: boolean;
   default?: any;
+  editable?: boolean;
   filter?: boolean;
+  nullable?: boolean;
   sort?: boolean;
 }
 

--- a/src/decorators/FloatField.ts
+++ b/src/decorators/FloatField.ts
@@ -9,6 +9,7 @@ import { WarthogField } from './WarthogField';
 
 interface FloatFieldOptions {
   dataType?: FloatColumnType; // int16, jsonb, etc...
+  default?: number;
   filter?: boolean;
   nullable?: boolean;
   sort?: boolean;
@@ -17,6 +18,7 @@ interface FloatFieldOptions {
 export function FloatField(args: FloatFieldOptions = decoratorDefaults): any {
   const options = { ...decoratorDefaults, ...args };
   const nullableOption = options.nullable === true ? { nullable: true } : {};
+  const defaultOption = options.default ? { default: options.default } : {};
   const databaseConnection: string = process.env.WARTHOG_DB_CONNECTION || '';
   const type = defaultColumnType(databaseConnection, 'float');
 
@@ -28,7 +30,8 @@ export function FloatField(args: FloatFieldOptions = decoratorDefaults): any {
     Column({
       // This type will be different per database driver
       type: args.dataType || type,
-      ...nullableOption
+      ...nullableOption,
+      ...defaultOption
     }) as MethodDecoratorFactory
   ];
 

--- a/src/decorators/IntField.ts
+++ b/src/decorators/IntField.ts
@@ -9,6 +9,7 @@ import { WarthogField } from './WarthogField';
 
 interface IntFieldOptions {
   dataType?: IntColumnType;
+  default?: number;
   filter?: boolean;
   nullable?: boolean;
   sort?: boolean;
@@ -16,6 +17,7 @@ interface IntFieldOptions {
 
 export function IntField(args: IntFieldOptions = decoratorDefaults): any {
   const options = { ...decoratorDefaults, ...args };
+  const defaultOption = options.default ? { default: options.default } : {};
   const nullableOption = options.nullable === true ? { nullable: true } : {};
 
   const factories = [
@@ -25,7 +27,8 @@ export function IntField(args: IntFieldOptions = decoratorDefaults): any {
     }),
     Column({
       type: args.dataType || 'int',
-      ...nullableOption
+      ...nullableOption,
+      ...defaultOption
     }) as MethodDecoratorFactory
   ];
 

--- a/src/decorators/StringField.ts
+++ b/src/decorators/StringField.ts
@@ -15,6 +15,7 @@ interface StringFieldOptions {
   nullable?: boolean;
   sort?: boolean;
   unique?: boolean;
+  editable?: boolean;
 }
 
 export function StringField(args: StringFieldOptions = decoratorDefaults): any {

--- a/src/schema/TypeORMConverter.ts
+++ b/src/schema/TypeORMConverter.ts
@@ -11,6 +11,26 @@ import {
 
 const ignoreBaseModels = ['BaseModel', 'BaseModelUUID'];
 
+export function getColumnsForModel(model: ModelMetadata) {
+  const models = [model];
+  const columns: { [key: string]: ColumnMetadata } = {};
+
+  let superProto = model.klass ? model.klass.__proto__ : null;
+  while (superProto) {
+    const superModel = getMetadataStorage().getModel(superProto.name);
+    superModel && models.unshift(superModel);
+    superProto = superProto.__proto__;
+  }
+
+  models.forEach(aModel => {
+    aModel.columns.forEach((col: ColumnMetadata) => {
+      columns[col.propertyName] = col;
+    });
+  });
+
+  return Object.values(columns);
+}
+
 export function filenameToImportPath(filename: string): string {
   return filename.replace(/\.(j|t)s$/, '').replace(/\\/g, '/');
 }
@@ -73,7 +93,8 @@ export function entityToWhereUniqueInput(model: ModelMetadata): string {
 
   let fieldsTemplate = '';
 
-  model.columns.forEach((column: ColumnMetadata) => {
+  const modelColumns = getColumnsForModel(model);
+  modelColumns.forEach((column: ColumnMetadata) => {
     // Uniques can be from Field or Unique annotations
     if (!modelUniques[column.propertyName]) {
       return;
@@ -126,7 +147,8 @@ export function entityToCreateInput(model: ModelMetadata): string {
     `;
   }
 
-  model.columns.forEach((column: ColumnMetadata) => {
+  const modelColumns = getColumnsForModel(model);
+  modelColumns.forEach((column: ColumnMetadata) => {
     if (!column.editable) {
       return;
     }
@@ -174,7 +196,8 @@ export function entityToCreateInput(model: ModelMetadata): string {
 export function entityToUpdateInput(model: ModelMetadata): string {
   let fieldTemplates = '';
 
-  model.columns.forEach((column: ColumnMetadata) => {
+  const modelColumns = getColumnsForModel(model);
+  modelColumns.forEach((column: ColumnMetadata) => {
     if (!column.editable) {
       return;
     }
@@ -241,7 +264,8 @@ function columnToTypes(column: ColumnMetadata) {
 export function entityToWhereInput(model: ModelMetadata): string {
   let fieldTemplates = '';
 
-  model.columns.forEach((column: ColumnMetadata) => {
+  const modelColumns = getColumnsForModel(model);
+  modelColumns.forEach((column: ColumnMetadata) => {
     // Don't allow filtering on these fields
     if (!column.filter) {
       return;
@@ -423,35 +447,15 @@ export function entityToCreateManyArgs(model: ModelMetadata): string {
 }
 
 export function entityToOrderByEnum(model: ModelMetadata): string {
-  const metadata = getMetadataStorage();
-  const superName = model.klass ? model.klass.__proto__.name : null;
-  const superModel = superName ? metadata.getModel(superName) : undefined;
-
   let fieldsTemplate = '';
-  const hitCache: { [key: string]: boolean } = {};
 
-  if (superModel) {
-    superModel.columns.forEach((column: ColumnMetadata) => {
-      if (column.type === 'json') {
-        return;
-      }
-
-      if (column.sort) {
-        hitCache[column.propertyName] = true;
-        fieldsTemplate += `
-          ${column.propertyName}_ASC = '${column.propertyName}_ASC',
-          ${column.propertyName}_DESC = '${column.propertyName}_DESC',
-        `;
-      }
-    });
-  }
-
-  model.columns.forEach((column: ColumnMetadata) => {
+  const modelColumns = getColumnsForModel(model);
+  modelColumns.forEach((column: ColumnMetadata) => {
     if (column.type === 'json') {
       return;
     }
 
-    if (column.sort && !hitCache[column.propertyName]) {
+    if (column.sort) {
       fieldsTemplate += `
         ${column.propertyName}_ASC = '${column.propertyName}_ASC',
         ${column.propertyName}_DESC = '${column.propertyName}_DESC',

--- a/src/schema/TypeORMConverter.ts
+++ b/src/schema/TypeORMConverter.ts
@@ -74,6 +74,7 @@ export function entityToWhereUniqueInput(model: ModelMetadata): string {
   let fieldsTemplate = '';
 
   model.columns.forEach((column: ColumnMetadata) => {
+    // Uniques can be from Field or Unique annotations
     if (!modelUniques[column.propertyName]) {
       return;
     }


### PR DESCRIPTION
Fixed a bunch of issues:
- takes @Unique() annotations into account when generating code
- allows default value for BooleanField to be false
- allows BooleanField to be marked as editable: false, which omits from Create/UpdateInputs
- adds default annotation option for IntField and FloatField
- allows EnumField & StringField to be marked as editable, see note above
- add new getColumnsForModels() function, which gathers column metadata from a model, including all super class models (also de-dupes them...)
- applied ^ to all Code generation utilities, where `model.columns` was used (code generation for Type, CreateInput, UpdateInput, WhereUniqueInput, WhereInput and Sort enums...)