### PR TITLE
fix(server): Add Option to Disable TypeGraphQL Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Almost all config in Warthog is driven by environment variables. The following i
 | WARTHOG_INTROSPECTION        | Allow server to be introspected             | true                        |
 | WARTHOG_MOCK_DATABASE        | Should we use mock sqlite DB?               | false                       |
 | WARTHOG_RESOLVERS_PATH       | Where should Warthog look for resolvers     | src/\*\*\/\*.resolver.ts    |
+| WARTHOG_VALIDATE_RESOLVERS   | TypeGraphQL validation enabled?             | false                       |
 
 ## Field/Column Decorators
 

--- a/src/cli/commands/codegen.ts
+++ b/src/cli/commands/codegen.ts
@@ -17,12 +17,13 @@ export default {
     try {
       await new CodeGenerator(config.get('GENERATED_FOLDER'), config.get('DB_ENTITIES'), {
         resolversPath: config.get('RESOLVERS_PATH'),
+        validateResolvers: config.get('VALIDATE_RESOLVERS') === 'true',
         warthogImportPath: config.get('MODULE_IMPORT_PATH')
       }).generate();
     } catch (error) {
       console.error(error); // eslint-disable-line
     }
 
-    cleanUpTestData();
+    await cleanUpTestData();
   }
 };

--- a/src/core/code-generator.ts
+++ b/src/core/code-generator.ts
@@ -22,6 +22,7 @@ const writeFilePromise = util.promisify(writeFile);
 
 interface CodeGeneratorOptions {
   resolversPath: string[];
+  validateResolvers?: boolean;
   warthogImportPath?: string;
 }
 
@@ -83,7 +84,7 @@ export class CodeGenerator {
           }
         ],
         resolvers: this.options.resolversPath,
-        validate: false // Generated input types do not include `class-validator` decorators
+        validate: this.options.validateResolvers
       });
       debug('code-generator:buildGraphQLSchema:end');
     }

--- a/src/core/code-generator.ts
+++ b/src/core/code-generator.ts
@@ -82,7 +82,8 @@ export class CodeGenerator {
             scalar: GraphQLID
           }
         ],
-        resolvers: this.options.resolversPath
+        resolvers: this.options.resolversPath,
+        validate: false // Generated input types do not include `class-validator` decorators
       });
       debug('code-generator:buildGraphQLSchema:end');
     }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -19,7 +19,8 @@ const CONFIG_VALUE_VALID_KEYS = [
   'generatedFolder',
   'cliGeneratePath',
   'moduleImportPath',
-  'resolversPath'
+  'resolversPath',
+  'validateResolvers'
 ];
 
 interface StaticConfigFile {
@@ -76,7 +77,8 @@ export class Config {
       WARTHOG_MODULE_IMPORT_PATH: 'warthog',
       // TODO: eventually we should do this path resolution when we ask for the variable with `get`
       WARTHOG_GENERATED_FOLDER: path.join(this.PROJECT_ROOT, 'generated'),
-      WARTHOG_RESOLVERS_PATH: [path.join(this.PROJECT_ROOT, 'src/**/*.resolver.ts')]
+      WARTHOG_RESOLVERS_PATH: [path.join(this.PROJECT_ROOT, 'src/**/*.resolver.ts')],
+      WARTHOG_VALIDATE_RESOLVERS: 'false'
     };
 
     this.devDefaults = {

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -189,6 +189,7 @@ export class Server<C extends BaseContext> {
     debug('start:generateFiles:start');
     await new CodeGenerator(this.config.get('GENERATED_FOLDER'), this.config.get('DB_ENTITIES'), {
       resolversPath: this.config.get('RESOLVERS_PATH'),
+      validateResolvers: this.config.get('VALIDATE_RESOLVERS') === 'true',
       warthogImportPath: this.config.get('MODULE_IMPORT_PATH')
     }).generate();
 

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -177,7 +177,7 @@ export class Server<C extends BaseContext> {
         globalMiddlewares: [DataLoaderMiddleware, ...(this.appOptions.middlewares || [])],
         resolvers: this.config.get('RESOLVERS_PATH'),
         // TODO: scalarsMap: [{ type: GraphQLDate, scalar: GraphQLDate }]
-        validate: false // Generated input types do not include `class-validator` decorators
+        validate: this.config.get('VALIDATE_RESOLVERS') === 'true'
       });
       debug('server:buildGraphQLSchema:end');
     }

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -175,8 +175,9 @@ export class Server<C extends BaseContext> {
         container: this.container as any,
         // TODO: ErrorLoggerMiddleware
         globalMiddlewares: [DataLoaderMiddleware, ...(this.appOptions.middlewares || [])],
-        resolvers: this.config.get('RESOLVERS_PATH')
+        resolvers: this.config.get('RESOLVERS_PATH'),
         // TODO: scalarsMap: [{ type: GraphQLDate, scalar: GraphQLDate }]
+        validate: false // Generated input types do not include `class-validator` decorators
       });
       debug('server:buildGraphQLSchema:end');
     }

--- a/src/core/tests/valid-config-file/.warthogrc.json
+++ b/src/core/tests/valid-config-file/.warthogrc.json
@@ -1,4 +1,5 @@
 {
   "generatedFolder": "./foo",
-  "resolversPath": "./r/e/s/o/l/v/e/r/s"
+  "resolversPath": "./r/e/s/o/l/v/e/r/s",
+  "validateResolvers": "true"
 }

--- a/src/core/tests/valid-config-file/config.test.ts
+++ b/src/core/tests/valid-config-file/config.test.ts
@@ -13,6 +13,7 @@ describe('Config (valid file)', () => {
 
     const vals: any = await config.loadStaticConfigSync();
 
+    expect(vals.WARTHOG_VALIDATE_RESOLVERS).toEqual('true');
     expect(vals.WARTHOG_GENERATED_FOLDER).toEqual(path.join(__dirname, './foo'));
     expect(vals.WARTHOG_RESOLVERS_PATH).toEqual('./r/e/s/o/l/v/e/r/s');
   });

--- a/src/test/server-vars.ts
+++ b/src/test/server-vars.ts
@@ -36,7 +36,8 @@ export function getStandardEnvironmentVariables(): StringMap {
     WARTHOG_DB_SYNCHRONIZE: 'true',
     WARTHOG_GENERATED_FOLDER: './src/test/generated',
     WARTHOG_RESOLVERS_PATH: './src/test/modules/**/*.resolver.ts',
-    WARTHOG_MODULE_IMPORT_PATH: '../../'
+    WARTHOG_MODULE_IMPORT_PATH: '../../',
+    WARTHOG_VALIDATE_RESOLVERS: 'false'
   };
 }
 


### PR DESCRIPTION
TypeGraphQL's usage of `class-validator` causes [unwanted noise to appear in logs](https://github.com/MichalLytek/type-graphql/issues/150) when no validation is specified.

Because Warthog's generated input types never contain `class-validator` decorators, disabling TypeGraphQL validation by default should have no effect besides removing the log noise.