### PR TITLE
feat(Model): Ability to pass TypeORM Entity options

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ Note that the examples in the [examples](./examples/README.md) folder use relati
 
 A model represents both a GraphQL type and a DB table. Warthog exposes a [BaseModel](https://github.com/goldcaddy77/warthog/blob/master/src/core/BaseModel.ts) class that provides the following columns for free: `id`, `createdAt`, `createdById`, `updatedAt`, `updatedById`, `deletedAt`, `deletedById`, `version`. If you use BaseModel in conjunction with BaseService (see below), all of these columns will be updated as you'd expect. The Warthog server will find all models that match the following glob - `'/**/*.model.ts'`. Ex: `user.model.ts`
 
+If you need to override default model options you may pass through the TypeORM [Entity](https://github.com/typeorm/typeorm/blob/master/docs/decorator-reference.md#entity) options into the `Model` decorator.
+
 #### Resolvers
 
 A Warthog resolver exposes queries (reading data) and mutations (writing data). They interact with the DB through `services` (described below) and typically make use of a bunch of auto-generated TypeScript types in the `generated` folder for things like sorting and filtering. Warthog will find all resolvers that match the following glob - `'/**/*.resolver.ts'`. Ex: `user.resolver.ts`

--- a/README.md
+++ b/README.md
@@ -185,8 +185,6 @@ Custom [TypeORM](https://github.com/typeorm/typeorm/blob/master/docs/decorator-r
 @Model({ api: { description: 'Custom description' }, db: { name: 'customtablename' } })
 ```
 
-If you need to override default model options you may pass through the TypeORM [Entity](https://github.com/typeorm/typeorm/blob/master/docs/decorator-reference.md#entity) options into the `Model` decorator.
-
 #### Resolvers
 
 A Warthog resolver exposes queries (reading data) and mutations (writing data). They interact with the DB through `services` (described below) and typically make use of a bunch of auto-generated TypeScript types in the `generated` folder for things like sorting and filtering. Warthog will find all resolvers that match the following glob - `'/**/*.resolver.ts'`. Ex: `user.resolver.ts`

--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ Note that the examples in the [examples](./examples/README.md) folder use relati
 
 A model represents both a GraphQL type and a DB table. Warthog exposes a [BaseModel](https://github.com/goldcaddy77/warthog/blob/master/src/core/BaseModel.ts) class that provides the following columns for free: `id`, `createdAt`, `createdById`, `updatedAt`, `updatedById`, `deletedAt`, `deletedById`, `version`. If you use BaseModel in conjunction with BaseService (see below), all of these columns will be updated as you'd expect. The Warthog server will find all models that match the following glob - `'/**/*.model.ts'`. Ex: `user.model.ts`
 
+Custom [TypeORM](https://github.com/typeorm/typeorm/blob/master/docs/decorator-reference.md#entity) and [TypeGraphQL](https://typegraphql.ml/docs/types-and-fields.html) options may be passed into the `Model` decorator using the following signature.
+
+```javascript
+@Model({ api: { description: 'Custom description' }, db: { name: 'customtablename' } })
+```
+
 If you need to override default model options you may pass through the TypeORM [Entity](https://github.com/typeorm/typeorm/blob/master/docs/decorator-reference.md#entity) options into the `Model` decorator.
 
 #### Resolvers

--- a/src/decorators/Model.ts
+++ b/src/decorators/Model.ts
@@ -1,13 +1,14 @@
 const caller = require('caller'); // eslint-disable-line @typescript-eslint/no-var-requires
 import * as path from 'path';
 import { ObjectType } from 'type-graphql';
-import { Entity } from 'typeorm';
+import { Entity, EntityOptions } from 'typeorm';
 
 import { ClassType } from '../core';
 import { getMetadataStorage } from '../metadata';
 import { ClassDecoratorFactory, composeClassDecorators, generatedFolderPath } from '../utils/';
 
-export function Model() {
+// Allow default TypeORM options to be used
+export function Model(entityOptions: EntityOptions = {}) {
   // In order to use the enums in the generated classes file, we need to
   // save their locations and import them in the generated file
   const modelFileName = caller();
@@ -22,7 +23,7 @@ export function Model() {
   };
 
   const factories = [
-    Entity() as ClassDecoratorFactory,
+    Entity(entityOptions) as ClassDecoratorFactory,
     ObjectType() as ClassDecoratorFactory,
     registerModelWithWarthog as ClassDecoratorFactory
   ];

--- a/src/decorators/Model.ts
+++ b/src/decorators/Model.ts
@@ -1,14 +1,20 @@
 const caller = require('caller'); // eslint-disable-line @typescript-eslint/no-var-requires
 import * as path from 'path';
 import { ObjectType } from 'type-graphql';
+import { ObjectOptions } from 'type-graphql/dist/decorators/ObjectType.d';
 import { Entity, EntityOptions } from 'typeorm';
 
 import { ClassType } from '../core';
 import { getMetadataStorage } from '../metadata';
 import { ClassDecoratorFactory, composeClassDecorators, generatedFolderPath } from '../utils/';
 
-// Allow default TypeORM options to be used
-export function Model(entityOptions: EntityOptions = {}) {
+interface ModelOptions {
+  api?: ObjectOptions;
+  db?: EntityOptions;
+}
+
+// Allow default TypeORM and TypeGraphQL options to be used
+export function Model({ api = {}, db = {} }: ModelOptions = {}) {
   // In order to use the enums in the generated classes file, we need to
   // save their locations and import them in the generated file
   const modelFileName = caller();
@@ -23,8 +29,8 @@ export function Model(entityOptions: EntityOptions = {}) {
   };
 
   const factories = [
-    Entity(entityOptions) as ClassDecoratorFactory,
-    ObjectType() as ClassDecoratorFactory,
+    Entity(db) as ClassDecoratorFactory,
+    ObjectType(api) as ClassDecoratorFactory,
     registerModelWithWarthog as ClassDecoratorFactory
   ];
 


### PR DESCRIPTION
**Problem**
When using the `Model` decorator sometimes it's necessary to specific the table name explicitly. For instance in the case of a model named `category`, I want the table to be named `categories`. As it sits, `warthog` would name it `categorys` 

**Solution**
Ability to use the standard `Entity` options TypeORM provides. Since the `Model` decorator essentially wraps the `Entity` decorator anyway, allow the use of the same options. 

**Usage**
`@Model({ name: 'categories' })`

I can add an example for this if need be.