### PR TITLE
fix(cli): db commands should read config

### DIFF
--- a/src/cli/extensions/db-extension.ts
+++ b/src/cli/extensions/db-extension.ts
@@ -142,7 +142,7 @@ function filteredProcessEnv() {
     }, {});
 }
 
-async function getPgConfig(config: any) {
+function getPgConfig(config: any) {
   return {
     host: config.get('DB_HOST'),
     user: config.get('DB_USERNAME'),


### PR DESCRIPTION
Fixes https://github.com/goldcaddy77/warthog/issues/323

I tested this locally and this code change causes the CLI to obey the DB config in the `.env` file