### PR TITLE
Fix for @Authorized() requests with no specific permissions

### DIFF
--- a/src/tgql/authChecker.ts
+++ b/src/tgql/authChecker.ts
@@ -9,7 +9,7 @@ export const authChecker: AuthChecker<BaseContext> = ({ context: { user } }, per
   }
 
   // Just checking @Authorized() - return true since we know there is a user now
-  if (user.permissions.length === 0) {
+  if (permissions.length === 0) {
     return user !== undefined;
   }
   // Check that permissions overlap


### PR DESCRIPTION
This is a line in authChecker that (from what I can tell) is supposed to handle authorized requests where there are no parameters in the `@Authorized` decorator. It simply passes when there is a user logged in and fails if the user is undefined. 

There was a typo in the code where, instead of checking how many permissions the request needs, it was checking how many permissions the user had. This was causing the authorization to always succeed when the user had 0 permissions. I made this change locally and my authorized resolvers started working.