### PR TITLE
README: update context form to return a Promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Most of the config in Warthog is done via environment variables (see `Config - E
 | ------------------------- | --------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
 | container                 | TypeDI container. Warthog uses dependency injection under the hood.                                       | empty container                               |
 | authChecker               | An instance of an [AuthChecker](https://typegraphql.ml/docs/authorization.html) to secure your resolvers. |                                               |
-| context                   | Context getter of form `(request: Request) => object`                                                     | empty                                         |
+| context                   | Context getter of form `(request: Request) => Promise<object>`                                                     | empty                                         |
 | logger                    | Logger                                                                                                    | [debug](https://github.com/visionmedia/debug) |
 | middlewares               | [TypeGraphQL](https://typegraphql.ml/docs/middlewares.html) middlewares to add to your server             | none                                          |
 | onBeforeGraphQLMiddleware | Callback executed just before the Graphql server is started. The Express app is passed.                   | none                                          |


### PR DESCRIPTION
This makes explicit that the context function may
be asynchronous which is already the fact.

Fixes #352 